### PR TITLE
Update terraform_validate_no_variables.sh

### DIFF
--- a/terraform_validate_no_variables.sh
+++ b/terraform_validate_no_variables.sh
@@ -11,7 +11,7 @@ for file_with_path in "$@"; do
   let "index+=1"
 done
 
-echo "${paths[*]}" | tr ' ' '\n' | sort -u
+echo "${paths[*]}" | tr ' ' '\n' | sort | uniq
 for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
 

--- a/terraform_validate_no_variables.sh
+++ b/terraform_validate_no_variables.sh
@@ -11,6 +11,7 @@ for file_with_path in "$@"; do
   let "index+=1"
 done
 
+echo "${paths[*]}" | tr ' ' '\n' | sort -u
 for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
 

--- a/terraform_validate_no_variables.sh
+++ b/terraform_validate_no_variables.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 declare -a paths
 index=0
@@ -14,9 +15,11 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
 
   pushd "$path_uniq" > /dev/null
+  echo "Running validate..."
   terraform validate -check-variables=false
 
-  echo "I am here"
+  echo "Exit code: $?"
+
   if [[ "$?" -ne 0 ]]; then
     echo
     echo "Failed path: $path_uniq"

--- a/terraform_validate_no_variables.sh
+++ b/terraform_validate_no_variables.sh
@@ -10,7 +10,9 @@ for file_with_path in "$@"; do
   paths[index]=$(dirname "$file_with_path")
   let "index+=1"
 done
-
+echo "${paths[*]}" 
+echo
+echo
 echo "${paths[*]}" | tr ' ' '\n' | sort | uniq
 for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   path_uniq="${path_uniq//__REPLACED__SPACE__/ }"

--- a/terraform_validate_no_variables.sh
+++ b/terraform_validate_no_variables.sh
@@ -15,6 +15,7 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
 
   pushd "$path_uniq" > /dev/null
+  set +e
   terraform validate -check-variables=false
 
   if [[ "$?" -ne 0 ]]; then
@@ -22,5 +23,7 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
     echo "Failed path: $path_uniq"
     echo "================================"
   fi
+  
+  set -e
   popd > /dev/null
 done

--- a/terraform_validate_no_variables.sh
+++ b/terraform_validate_no_variables.sh
@@ -21,7 +21,7 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
 
   if [[ "$?" -ne 0 ]]; then
     >&2 echo
-    >&2 echo "Failed path: $(pwd)"
+    >&2 echo "Failed path: $path_uniq"
     >&2 echo "================================"
     exit 1
   fi

--- a/terraform_validate_no_variables.sh
+++ b/terraform_validate_no_variables.sh
@@ -10,10 +10,7 @@ for file_with_path in "$@"; do
   paths[index]=$(dirname "$file_with_path")
   let "index+=1"
 done
-echo "${paths[*]}" 
-echo
-echo
-echo "${paths[*]}" | tr ' ' '\n' | sort | uniq
+
 for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
 

--- a/terraform_validate_no_variables.sh
+++ b/terraform_validate_no_variables.sh
@@ -16,15 +16,17 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
 
   pushd "$path_uniq" > /dev/null
   >&2 echo "Running validate..."
+
+  set +e
   terraform validate -check-variables=false
 
-  >&2 echo "Exit code: $?"
-
   if [[ "$?" -ne 0 ]]; then
-    echo
-    echo "Failed path: $path_uniq"
-    echo "================================"
+    >&2 echo
+    >&2 echo "Failed path: $path_uniq"
+    >&2 echo "================================"
+    exit 1
   fi
   
+  set -e
   popd > /dev/null
 done

--- a/terraform_validate_no_variables.sh
+++ b/terraform_validate_no_variables.sh
@@ -15,10 +15,10 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
 
   pushd "$path_uniq" > /dev/null
-  echo "Running validate..."
+  >&2 echo "Running validate..."
   terraform validate -check-variables=false
 
-  echo "Exit code: $?"
+  >&2 echo "Exit code: $?"
 
   if [[ "$?" -ne 0 ]]; then
     echo

--- a/terraform_validate_no_variables.sh
+++ b/terraform_validate_no_variables.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -e
 
 declare -a paths
 index=0

--- a/terraform_validate_no_variables.sh
+++ b/terraform_validate_no_variables.sh
@@ -22,6 +22,7 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
     echo
     echo "Failed path: $path_uniq"
     echo "================================"
+    exit 1
   fi
   
   set -e

--- a/terraform_validate_no_variables.sh
+++ b/terraform_validate_no_variables.sh
@@ -18,11 +18,11 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   set +e
   terraform validate -check-variables=false
 
+  echo "I am here"
   if [[ "$?" -ne 0 ]]; then
     echo
     echo "Failed path: $path_uniq"
     echo "================================"
-    exit 1
   fi
   
   set -e

--- a/terraform_validate_no_variables.sh
+++ b/terraform_validate_no_variables.sh
@@ -15,7 +15,6 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
 
   pushd "$path_uniq" > /dev/null
-  set +e
   terraform validate -check-variables=false
 
   echo "I am here"
@@ -25,6 +24,5 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
     echo "================================"
   fi
   
-  set -e
   popd > /dev/null
 done

--- a/terraform_validate_no_variables.sh
+++ b/terraform_validate_no_variables.sh
@@ -15,7 +15,6 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   path_uniq="${path_uniq//__REPLACED__SPACE__/ }"
 
   pushd "$path_uniq" > /dev/null
-  >&2 echo "Running validate..."
 
   set +e
   terraform validate -check-variables=false

--- a/terraform_validate_no_variables.sh
+++ b/terraform_validate_no_variables.sh
@@ -21,7 +21,7 @@ for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
 
   if [[ "$?" -ne 0 ]]; then
     >&2 echo
-    >&2 echo "Failed path: $path_uniq"
+    >&2 echo "Failed path: $(pwd)"
     >&2 echo "================================"
     exit 1
   fi


### PR DESCRIPTION
## Why

Before the hook was not printing out which path was failing because of `set -e`.

No it does actually print out the path but multiple times 😦  . We can fix that later