### PR TITLE
OPS-3811: Work around for race condition in terraform_readme hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -21,6 +21,7 @@
   language: script
   files: (\.tf)$
   exclude: \.terraform\/.*$
+  require_serial: true
 
 
 - id: terraform_validate_no_variables

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,6 +5,7 @@
   language: script
   files: (\.tf|\.tfvars)$
   exclude: \.terraform\/.*$
+  require_serial: true
 
 - id: terraform_docs
   name: Terraform Docs


### PR DESCRIPTION
pre-commit runs the hook for every file, and in parallel, makes it likely that within a few runs things will get clobbered.